### PR TITLE
fix(sideboard): Bravo now takes nullrune against Iyslander

### DIFF
--- a/packages/bot/src/sideboard.test.ts
+++ b/packages/bot/src/sideboard.test.ts
@@ -80,6 +80,19 @@ describe("Bravo Fabrary matchup presentation", () => {
     expect(presented.deck).not.toContain("SBR017");
   });
 
+  it("uses the anti-arcane package against Iyslander", () => {
+    const presented = bravoPresentationFor(opponent({ heroId: "SIY001" }));
+    expect(presented.equipment).toEqual({
+      head: "SBR006",
+      chest: "SBR007",
+      arms: "SGB006",
+      legs: "SBL010",
+    });
+    expect(presented.deck.filter((id) => id === "SBA030")).toHaveLength(2);
+    expect(presented.deck.filter((id) => id === "SLY019")).toHaveLength(2);
+    expect(presented.deck).not.toContain("SBR017");
+  });
+
   it("follows the Briar guide's second-player plan", () => {
     const presented = bravoPresentationFor(opponent({ heroId: "SBA001" }));
     expect(presented.equipment.head).toBe("SBR006");

--- a/packages/bot/src/sideboard.ts
+++ b/packages/bot/src/sideboard.ts
@@ -45,6 +45,7 @@ type BravoMatchup =
   | "dromai"
   | "enigma"
   | "fai"
+  | "iyslander"
   | "oldhim"
   | "olympia"
   | "oscilio"
@@ -380,6 +381,7 @@ function bravoMatchupFor(
   if (name.includes("dromai")) return "dromai";
   if (name.includes("enigma")) return "enigma";
   if (name.includes("fai")) return "fai";
+  if (name.includes("iyslander")) return "iyslander";
   if (name.includes("oldhim")) return "oldhim";
   if (name.includes("olympia")) return "olympia";
   if (name.includes("oscilio")) return "oscilio";
@@ -422,7 +424,7 @@ export function bravoPresentationFor(
   let deck = [...registered.pool.deck];
   let additions: string[];
 
-  if (matchup === "blaze") {
+  if (matchup === "blaze" || matchup === "iyslander") {
     deck = deck.filter((id) => id !== "SBR017");
     additions = [...BRAVO_ARCANE_POLARITY, ...BRAVO_OASIS, ...BRAVO_PUMMEL];
   } else if (matchup === "bravo") {
@@ -443,7 +445,7 @@ export function bravoPresentationFor(
     throw new Error(`Bravo matchup presentation has ${deck.length} cards, expected 40`);
   }
 
-  const arcaneEquipment = matchup === "blaze" || matchup === "oscilio";
+  const arcaneEquipment = matchup === "blaze" || matchup === "iyslander" || matchup === "oscilio";
   const briarEquipment = matchup === "briar";
   return {
     weaponIds: ["SLY002", "SBR004"],


### PR DESCRIPTION
Bravo Sage bot missed Iyslander sideboard info, so used no arcane barrier at all.