### PR TITLE
Fix `Deep Rooted Evil` card with conditional play-from-banish ability

### DIFF
--- a/packages/cards/src/__tests__/scenarios/mon.test.ts
+++ b/packages/cards/src/__tests__/scenarios/mon.test.ts
@@ -391,6 +391,41 @@ describe("MON — Shadow Brute and Blood Debt", () => {
     });
     expect(legalIntents(faceDown.state, 0).filter((i) => i.kind === "play-card")).toEqual([]);
   });
+
+  it("Blood-debt attacks with conditional permission can be played from hand", () => {
+    const s = scenario({
+      seats: [
+        leviaSeat({ banish: [], hand: [BLUE, "deep rooted evil|2"] }),
+        { hero: "dorinthea" },
+      ],
+    });
+    s.state.players[0]!.flags.banishedSixPlusThisTurn = false;
+
+    s.play("deep rooted evil|2", { pitch: [BLUE] })
+      .blockWith()
+      .settle()
+      .expectFinalAttack(6)
+  });
+
+  it("Blood-debt attacks with conditional permission can be played from banish", () => {
+    const s = scenario({
+      seats: [leviaSeat({ banish: ["deep rooted evil|2"], hand: [BLUE] }), { hero: "dorinthea" }],
+    });
+    s.state.players[0]!.flags.banishedSixPlusThisTurn = true;
+
+    s.play("deep rooted evil|2", { pitch: [BLUE], fromZone: "banish" })
+      .blockWith()
+      .settle()
+      .expectFinalAttack(6)
+  });
+
+  it("Blood-debt attacks with conditional permission cannot be played from banish", () => {
+    const s = scenario({
+      seats: [leviaSeat({ banish: ["deep rooted evil|2"], hand: [BLUE] }), { hero: "dorinthea" }],
+    });
+    s.state.players[0]!.flags.banishedSixPlusThisTurn = false;
+    expect(legalIntents(s.state, 0).filter((i) => i.kind === "play-card")).toEqual([]);
+  });
 });
 
 describe("MON — Chane and banished-zone play", () => {

--- a/packages/cards/src/scripts/mon/high-rarity.ts
+++ b/packages/cards/src/scripts/mon/high-rarity.ts
@@ -249,7 +249,12 @@ export const monHighRarity: Record<string, CardScript> = {
   "valiant dynamo|0": { triggers: [{ event: "end-of-turn", optional: true, defaultOption: "yes", condition: (ctx) => weaponAttackCount(ctx) >= 2, label: "Recover Valiant Dynamo", effect(ctx) { ctx.addCardDefenseCounters(ctx.self.instanceId, -1); } }] },
   "spill blood|1": { onPlay(ctx) { ctx.addModifier({ scope: "until-end-of-turn", attack: 2, appliesTo: "weapon" }); ctx.addModifier({ scope: "until-end-of-turn", dominate: true, appliesTo: "weapon" }); } },
   "hexagore, the death hydra|0": weapon(2, { onAttackDeclared(ctx) { const blood = ctx.player(ctx.seat).banish.filter((card) => !card.faceDown && (ctx.cardData(card.cardId).keywords ?? []).some((keyword) => keyword.toLowerCase() === "blood debt")).length; ctx.dealDamage(ctx.seat, Math.max(0, 6 - blood), { sourceInstanceId: ctx.self.instanceId }); } }),
-  "deep rooted evil|2": bloodDebt({ canPlay: (ctx) => Number(ctx.getFlag("player", "banishedThisTurn")) >= 6 }, true),
+  "deep rooted evil|2": bloodDebt({ 
+    staticPlayableFrom: ["banish"],
+    canPlay: (ctx) => {
+      const inBanish = ctx.player(ctx.seat).banish.some((card) => card.instanceId === ctx.self.instanceId);
+      return !inBanish || ctx.getFlag("player", "banishedSixPlusThisTurn") === true;
+  }}, true),
   "mark of the beast|2": bloodDebt({ graveyardReplacement: "banish" }),
   "shadow of blasmophet|1": bloodDebt({ onAttackDeclared(ctx) { ctx.drawCards(ctx.seat, 1); if (randomDiscardSix(ctx)) { const cards = ctx.player(ctx.seat).deck.filter((card) => (ctx.cardData(card.cardId).keywords ?? []).some((keyword) => keyword.toLowerCase() === "blood debt")); if (cards.length) ctx.requestCardChoice("blasmophet-search", decisionPrompt("Choose a Blood Debt card", "card.mon.blooddebt.card.choose"), cards.map((card) => card.instanceId)); } }, onChoose(ctx, hook, option) { if (hook === "blasmophet-search" && ctx.banish(Number(option))) ctx.shuffleDeck(); } }),
   "chane, bound by shadow|0": { activated: { cost: 0, isAttack: false, goAgain: true, oncePerTurn: true, onActivate(ctx) { ctx.createToken(SOUL_SHACKLE); buffNextAttack(ctx, { goAgain: true, appliesToType: ["runeblade", "shadow"] }); } } },


### PR DESCRIPTION
# Summary
Fix conditional play-from-banish ability for `deep rooted evil|2` to allow play from hand or banish if a 6+ card was banished this turn.

# Problem
Previously, `deep rooted evil|2` was checking if a card was banished this turn to be able to play (at all). This is the incorrect conditional check for play-from-banish and disables playing from hand normally.

# Testing
pnpm --filter @fyendal/cards test 92 files, 1888 tests
pnpm --filter @fyendal/cards typecheck

### Deployment
This changes card rules behavior; coordinate the operator-managed `rulesetVersion` for deployment as required.
